### PR TITLE
No students check on GET /students route

### DIFF
--- a/server/routes/students.js
+++ b/server/routes/students.js
@@ -23,10 +23,15 @@ router.get('/', (req,res,next) => {
             .find({cohort: cohortQuery})
             .sort({'name.last': 1})
             .exec((err, students) => {
-                if (err) {
-                    res.status(400).send('Make sure cohort query represents a valid cohort');                    
-                }
-                res.send(students);
+              if (err) {
+                  res.status(400).send('Make sure cohort query represents a valid cohort');                    
+              }
+              //checking for cohorts without students
+              if(students.length === 0){
+                return res.send('There are no students within that cohort');
+              }
+              
+              res.send(students);
             })
     }
 })


### PR DESCRIPTION
Server will respond with string 'There are no students within that cohort' - this is designed to check edge case if the cohort number searched for within URL query is larger than  present within DB.