### PR TITLE
Fixed spacing between view/edit/employer view links

### DIFF
--- a/server/client/src/components/admin/PackageRow.js
+++ b/server/client/src/components/admin/PackageRow.js
@@ -16,9 +16,9 @@ class PackageRow extends Component {
         <td>{this.formatDate(currentPackage.created_at)}</td>
       
         <td>
-          <Link to={`/admin/package/${currentPackage._id}`}> <span className='badge badge-secondary' style={{backgroundColor: '#679AB8'}}>View</span></Link>
-          <Link to={`/admin/editpackage/${currentPackage._id}`}> <span className='badge badge-secondary' style={{backgroundColor: '#679AB8'}}>Edit</span></Link>
-          <Link to={`/employer/${currentPackage._id}`}> <span className='badge badge-secondary' style={{backgroundColor: '#679AB8'}}>Employer View</span></Link>
+          <Link to={`/admin/package/${currentPackage._id}`}><span className='badge badge-secondary mr-1' style={{backgroundColor: '#679AB8'}}>View</span></Link>
+          <Link to={`/admin/editpackage/${currentPackage._id}`}><span className='badge badge-secondary mr-1' style={{backgroundColor: '#679AB8'}}>Edit</span></Link>
+          <Link to={`/employer/${currentPackage._id}`}><span className='badge badge-secondary mr-1' style={{backgroundColor: '#679AB8'}}>Employer View</span></Link>
         </td>
        
       </tr>

--- a/server/client/src/components/admin/StudentRow.js
+++ b/server/client/src/components/admin/StudentRow.js
@@ -15,8 +15,8 @@ class StudentRow extends Component {
         <td style={{textAlign: 'left'}}>{student.cohort}</td>
         <td>{student.jobSeekingStatus}</td>
         <td>
-          <Link to={`/admin/student/${student._id}`}> <span className='badge badge-secondary' style={{backgroundColor: '#679AB8'}}>View</span></Link>
-          <Link to={`/admin/editstudent/${student._id}`}> <span className='badge badge-secondary' style={{backgroundColor: '#679AB8'}}>Edit</span></Link>
+          <Link to={`/admin/student/${student._id}`}><span className='badge badge-secondary mr-1' style={{backgroundColor: '#679AB8'}}>View</span></Link>
+          <Link to={`/admin/editstudent/${student._id}`}><span className='badge badge-secondary' style={{backgroundColor: '#679AB8'}}>Edit</span></Link>
         </td>
       </tr>
     )


### PR DESCRIPTION
Previously the space between view/edit/view as employer had an underline on hover. Now properly styled.